### PR TITLE
Proposed fix to remove  extra chars between agent's first and last names.

### DIFF
--- a/src/OpenRealEstate.Transmorgrifiers.RealestateComAu/Extensions/SystemExtensions.cs
+++ b/src/OpenRealEstate.Transmorgrifiers.RealestateComAu/Extensions/SystemExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -102,16 +102,16 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu.Extensions
         /// </summary>
         /// <param name="value">string: value to check and potentially clean.</param>
         /// <returns>string: Cleaned string/text.</returns>
-        internal static string RemoveAnyExtraSpaces(this string value)
+        internal static string RemoveExtraCharsBetweenWords(this string value)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
                 throw new ArgumentNullException(nameof(value));
             }
 
-            return string.Join(" ", value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
+            return string.Join(" ", value.Split(new[] { ' ', '\r', '\n', '\t' },
+                                                StringSplitOptions.RemoveEmptyEntries));
         }
-
         private static int ParseNumberToIntOrDefault(this string value)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -128,7 +128,7 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu.Extensions
             if (float.TryParse(value, out var number) &&
                 Math.Abs((number % 1)) < 0.01)
             {
-                return (int) number;
+                return (int)number;
             }
 
             var errorMessage = string.Format("Failed to parse the value '{0}' into an int. Is it a valid number? Does it contain decimal point values?", value);

--- a/src/OpenRealEstate.Transmorgrifiers.RealestateComAu/ReaXmlTransmorgrifier.cs
+++ b/src/OpenRealEstate.Transmorgrifiers.RealestateComAu/ReaXmlTransmorgrifier.cs
@@ -798,7 +798,7 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu
 
                 var agent = new Agent
                 {
-                    Name = name.RemoveAnyExtraSpaces()
+                    Name = name.RemoveExtraCharsBetweenWords()
                 };
 
                 var orderValue = agentElement.AttributeValueOrDefault("id");

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/Extensions/SystemExtensionsTests.cs
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/Extensions/SystemExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using OpenRealEstate.Transmorgrifiers.RealEstateComAu.Extensions;
+using OpenRealEstate.Transmorgrifiers.RealEstateComAu.Extensions;
 using Shouldly;
 using Xunit;
 
@@ -18,10 +18,13 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests.Extensions
         [InlineData(" a b c d e f ", "a b c d e f")]
         [InlineData("  a  b  c  d  e  f ", "a b c d e f")]
         [InlineData(" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                                                           a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa a")]
+        [InlineData(" abc  \n cde", "abc cde")]
+        [InlineData(" abc  \r cde ", "abc cde")]
+        [InlineData("  abc   \t \n cde  ", "abc cde")]
         public void GivenAString_RemoveAnyExtraSpaces_ReturnsACleanedString(string sourceText, string expectedText)
         {
             // Arrange & Act.
-            var result = sourceText.RemoveAnyExtraSpaces();
+            var result = sourceText.RemoveExtraCharsBetweenWords();
 
             // Assert.
             result.ShouldBe(expectedText);


### PR DESCRIPTION
Xml file may contain invalid char(10) chars '\n' between first and last names.