### PR TITLE
🔧 Fix crash -> attachment content-type is optional

### DIFF
--- a/src/OpenRealEstate.Transmorgrifiers.RealEstateComAu/ReaXmlTransmorgrifier.cs
+++ b/src/OpenRealEstate.Transmorgrifiers.RealEstateComAu/ReaXmlTransmorgrifier.cs
@@ -24,7 +24,7 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu
     {
         private static readonly Regex RemoveHtmlRegex = new Regex("<[a-zA-Z/].*?>", RegexOptions.Compiled);
 
-        private static readonly IList<string> ValidRootNodes = new List<string>
+        private static readonly string[] ValidRootNodes = new string[]
         {
             "propertyList",
             "residential",
@@ -98,6 +98,15 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu
             "0000-00-00-00:00:00",
             "0000-00-00T00:00:00"
         };
+
+        private static readonly string[] ValidAttachmentTags = new[]
+        {
+            "statementOfInformation",
+            "agentPhoto" // Not used by OpenRealEstate
+        };
+
+        private const string AttachmentContentTypeApplicationPdf = "application/pdf";
+        private static readonly string[] ValidAttachmentContentTypes = new[] { AttachmentContentTypeApplicationPdf };
 
         private CultureInfo _defaultCultureInfo;
 
@@ -1299,45 +1308,54 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu
             {
                 return;
             }
-
-            const string validTag = "StatementOfInformation";
-            const string validContentType = "application/pdf";
+            
 
             // Notes: Will only extract documents that:
-            // 1 - Are a 'Statement Of Information'
-            // 2 - First SoI document.
+            // 1 - Are a 'Statement Of Information'. We ignore 'Agent Photos'.
+            // 2 - First SoI document (if there are multiple).
+            // 3 - If no ContentType was provided, then we force it to application/pdf.
             var documents = mediaElement.Elements("attachment")
                                         .Select((e,
-                                                order) => new Media
-                                                {
-                                                    CreatedOn = DateTime.UtcNow,
-                                                    Id = e.AttributeValueOrDefault("id"),
-                                                    Tag = e.AttributeValueOrDefault("usage"),
-                                                    Url = e.AttributeValueOrDefault("url"),
-                                                    ContentType = e.AttributeValueOrDefault("contentType"),
-                                                    Order = ++order
-                                                })
+                                                 order) => new Media
+                                                 {
+                                                     CreatedOn = DateTime.UtcNow,
+                                                     Id = e.AttributeValueOrDefault("id"),
+                                                     Tag = e.AttributeValueOrDefault("usage"),
+                                                     Url = e.AttributeValueOrDefault("url"),
+                                                     ContentType = string.IsNullOrWhiteSpace(e.AttributeValueOrDefault("contentType")) // ContentType is now optional!
+                                                        ? AttachmentContentTypeApplicationPdf
+                                                        : e.AttributeValueOrDefault("contentType"), 
+                                                     Order = ++order
+                                                 })
                                         .OrderBy(x => x.Order)
                                         .ToList();
 
-            var invalidTags = documents.Where(x => !x.Tag.Equals(validTag, StringComparison.OrdinalIgnoreCase))
-                                       .Select(x => x.Tag);
+            var invalidTags = documents.Where(x => !string.IsNullOrWhiteSpace(x.Tag))
+                                       .Select(x => x.Tag)
+                                       .Except(ValidAttachmentTags, StringComparer.OrdinalIgnoreCase);
+
             if (invalidTags.Any())
             {
                 var errorMessage = $"At least 1 document has an invalid 'usage' value. Invalid values: {string.Join(", ", invalidTags)}";
                 warnings.Add(errorMessage);
             }
 
-            var invalidContentTypes = documents.Where(x => !x.ContentType.Equals(validContentType, StringComparison.OrdinalIgnoreCase))
-                                               .Select(x => x.ContentType);
+            var invalidContentTypes = documents.Where(x => !string.IsNullOrWhiteSpace(x.ContentType))
+                                               .Select(x => x.ContentType)
+                                               .Except(ValidAttachmentContentTypes, StringComparer.OrdinalIgnoreCase);
             if (invalidContentTypes.Any())
             {
                 var errorMessage = $"At least 1 document has an invalid 'contentType' value. Invalid values: {string.Join(", ", invalidContentTypes)}";
                 warnings.Add(errorMessage);
             }
 
-            listing.Documents = documents.Where(x => x.Tag.Equals(validTag, StringComparison.OrdinalIgnoreCase) &&
-                                                     x.ContentType.Equals(validContentType, StringComparison.OrdinalIgnoreCase))
+            // We only want documents that
+            // - are legit (no warnings, from above)
+            // - only statementOfInformation's. Not handling agentPhoto's.
+
+            listing.Documents = documents.Where(x => !invalidTags.Contains(x.Tag, StringComparer.OrdinalIgnoreCase) &&
+                                                     (string.IsNullOrWhiteSpace(x.ContentType) || 
+                                                      x.ContentType.Equals(AttachmentContentTypeApplicationPdf, StringComparison.OrdinalIgnoreCase)))
                                          .ToList();
         }
 

--- a/src/OpenRealEstate.Transmorgrifiers.RealEstateComAu/ReaXmlTransmorgrifier.cs
+++ b/src/OpenRealEstate.Transmorgrifiers.RealEstateComAu/ReaXmlTransmorgrifier.cs
@@ -99,9 +99,11 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu
             "0000-00-00T00:00:00"
         };
 
+
+        private const string AttachmentTagStatementOfInformation = "statementOfInformation";
         private static readonly string[] ValidAttachmentTags = new[]
         {
-            "statementOfInformation",
+            AttachmentTagStatementOfInformation,
             "agentPhoto" // Not used by OpenRealEstate
         };
 
@@ -1354,8 +1356,8 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu
             // - only statementOfInformation's. Not handling agentPhoto's.
 
             listing.Documents = documents.Where(x => !invalidTags.Contains(x.Tag, StringComparer.OrdinalIgnoreCase) &&
-                                                     (string.IsNullOrWhiteSpace(x.ContentType) || 
-                                                      x.ContentType.Equals(AttachmentContentTypeApplicationPdf, StringComparison.OrdinalIgnoreCase)))
+                                                     !invalidContentTypes.Contains(x.ContentType, StringComparer.OrdinalIgnoreCase) &&
+                                                     x.Tag.Equals(AttachmentTagStatementOfInformation, StringComparison.OrdinalIgnoreCase))
                                          .ToList();
         }
 

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests.csproj
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests.csproj
@@ -93,6 +93,9 @@
     <None Update="Sample Data\Rental\REA-Segment-Rental-Current.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Sample Data\Residential\REA-Residential-Current-WithAgentPhotAttachment.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Sample Data\Residential\REA-Residential-Current-WithNoAttachmentContentType.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests.csproj
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests.csproj
@@ -93,6 +93,9 @@
     <None Update="Sample Data\Rental\REA-Segment-Rental-Current.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Sample Data\Residential\REA-Residential-Current-WithNoAttachmentContentType.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Sample Data\Residential\REA-Residential-Current-WithHeadlineAndDescriptionPlaceholders.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/ParseResidentialTests.cs
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/ParseResidentialTests.cs
@@ -114,6 +114,7 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests
         [InlineData("REA-Residential-Current-WithBuildingDetailsAreaHavingARange.xml")]
         [InlineData("REA-Residential-Current-WithCData.xml")]
         [InlineData("REA-Residential-Current-WithNoAttachmentContentType.xml")]
+        [InlineData("REA-Residential-Current-WithAgentPhotAttachment.xml")]
         public void GivenTheFileREAResidentialCurrent_Parse_ReturnsAResidentialAvailableListing(string fileName)
         {
             // Arrange.

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/ParseResidentialTests.cs
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/ParseResidentialTests.cs
@@ -113,6 +113,7 @@ namespace OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests
         [InlineData("REA-Residential-Current-WithOptionalAuctionDateTimeText.xml")]
         [InlineData("REA-Residential-Current-WithBuildingDetailsAreaHavingARange.xml")]
         [InlineData("REA-Residential-Current-WithCData.xml")]
+        [InlineData("REA-Residential-Current-WithNoAttachmentContentType.xml")]
         public void GivenTheFileREAResidentialCurrent_Parse_ReturnsAResidentialAvailableListing(string fileName)
         {
             // Arrange.

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/Sample Data/Residential/REA-Residential-Current-WithAgentPhotAttachment.xml
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/Sample Data/Residential/REA-Residential-Current-WithAgentPhotAttachment.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE propertyList SYSTEM "http://reaxml.realestate.com.au/propertyList.dtd">
+<propertyList date="2009-01-01-12:30:00" username="xmluser" password="xmlpassword">
+    <!-- Current listing -->
+    <residential modTime="2009-01-01-12:30:00" status="current">
+        <agentID>XNWXNW</agentID>
+        <uniqueID>Residential-Current-ABCD1234</uniqueID>
+        <authority value="auction" />
+        <auction date="2009-02-04T18:30" />
+        <underOffer value="no" />
+        <councilRates>$2000 per month</councilRates>
+        <isHomeLandPackage value="yes"></isHomeLandPackage>
+        <newConstruction>1</newConstruction>
+        <listingAgent>
+            <name>Mr. John Doe</name>
+            <telephone type="BH">05 1234 5678</telephone>
+            <telephone type="mobile">0418 123 456</telephone>
+            <email>jdoe@somedomain.com.au</email>
+            <twitterURL>https://www.twitter.com/JohnDoe</twitterURL>
+        </listingAgent>
+        <price display="yes">500000</price>
+        <priceView>Between $400,000 and $600,000</priceView>
+        <address display="yes">
+            <subNumber>2</subNumber>
+            <streetNumber>39</streetNumber>
+            <street>Main Road</street>
+            <suburb display="yes">RICHMOND</suburb>
+            <state>Vic</state>
+            <postcode>3121</postcode>
+            <country>AUS</country>
+        </address>
+        <municipality>Yarra</municipality>
+        <streetDirectory type="melways">
+            <page>44</page>
+            <reference>G7</reference>
+        </streetDirectory>
+        <category name="House" />
+        <headline>SHOW STOPPER!!!</headline>
+        <description>Don't pass up an opportunity like this! First to inspect will buy! Close to local amenities and schools. Features lavishly appointed bathrooms, modern kitchen, rustic outhouse.Don't pass up an opportunity like this! First to inspect will buy! Close to local amenities and schools. Features lavishly appointed bathrooms, modern kitchen, rustic outhouse.</description>
+        <features>
+            <bedrooms>4</bedrooms>
+            <bathrooms>2</bathrooms>
+            <ensuite>2</ensuite>
+            <garages>3</garages>
+            <carports>2</carports>
+            <remoteGarage>yes</remoteGarage>
+            <secureParking>yes</secureParking>
+            <airConditioning>1</airConditioning>
+            <alarmSystem>1</alarmSystem>
+            <vacuumSystem>no</vacuumSystem>
+            <intercom>no</intercom>
+            <pool type="inground">yes</pool>
+            <spa type="inground">no</spa>
+            <tennisCourt>yes</tennisCourt>
+            <balcony>yes</balcony>
+            <deck>yes</deck>
+            <courtyard>yes</courtyard>
+            <outdoorEnt>yes</outdoorEnt>
+            <shed>yes</shed>
+            <fullyFenced>yes</fullyFenced>
+            <openFirePlace>1</openFirePlace>
+            <heating type="other" />
+            <hotWaterService type="gas" />
+            <otherFeatures>balcony, courtyard, shed</otherFeatures>
+        </features>
+        <landDetails>
+            <area unit="squareMeter">80</area>
+            <frontage unit="meter">20</frontage>
+            <depth unit="meter" side="rear">40</depth>
+            <depth unit="meter" side="left">60</depth>
+            <depth unit="meter" side="right">20</depth>
+            <crossOver value="left" />
+        </landDetails>
+        <buildingDetails>
+            <area unit="squareMeter">40</area>
+            <newlyBuilt value="yes" />
+            <energyRating>4.5</energyRating>
+        </buildingDetails>
+        <inspectionTimes>
+            <inspection>21-Jan-2009 11:00am to 1:00pm</inspection>
+            <inspection>22-Jan-2009 3:00pm to 3:30pm</inspection>
+        </inspectionTimes>
+        <vendorDetails>
+            <name>Mr. John Doe</name>
+            <telephone type="BH">05 1234 5678</telephone>
+        </vendorDetails>
+        <externalLink href="http%3A%2F%2Fwww%2Eau%2Eopen2view%2Ecom%2Fproperties%2F314244%2Ftour%23floorplan" />
+        <externalLink href="http://www.google.com/hello" />
+        <images>
+            <img id="m" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/imageM.jpg" format="jpg" />
+            <img id="a" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/imageA.jpg" format="jpg" />
+        </images>
+        <objects>
+            <floorplan id="1" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/floorplan1.gif"
+                       format="gif" />
+            <floorplan id="2" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/floorplan2.gif"
+                       format="gif" />
+        </objects>
+        <media>
+            <attachment usage="statementOfInformation" contentType="application/pdf" id="aaaa1111" url="http://www.someWebSite.com.au/tmp/soi-doc-1.gif"></attachment>
+            <attachment usage="agentPhoto" id="2222" url="http://www.someWebSite.com.au/tmp/agentphoto.gif"></attachment>
+        </media>
+        <videoLink href="http://www.foo.tv/abcd.html"/>
+        <ecoFriendly>
+            <solarPanels>1</solarPanels>
+            <solarHotWater>0</solarHotWater>
+            <waterTank>1</waterTank>
+            <greyWaterSystem>0</greyWaterSystem>
+        </ecoFriendly>
+    </residential>
+</propertyList>

--- a/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/Sample Data/Residential/REA-Residential-Current-WithNoAttachmentContentType.xml
+++ b/tests/OpenRealEstate.Transmorgrifiers.RealEstateComAu.Tests/Sample Data/Residential/REA-Residential-Current-WithNoAttachmentContentType.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE propertyList SYSTEM "http://reaxml.realestate.com.au/propertyList.dtd">
+<propertyList date="2009-01-01-12:30:00" username="xmluser" password="xmlpassword">
+    <!-- Current listing -->
+    <residential modTime="2009-01-01-12:30:00" status="current">
+        <agentID>XNWXNW</agentID>
+        <uniqueID>Residential-Current-ABCD1234</uniqueID>
+        <authority value="auction" />
+        <auction date="2009-02-04T18:30" />
+        <underOffer value="no" />
+        <councilRates>$2000 per month</councilRates>
+        <isHomeLandPackage value="yes"></isHomeLandPackage>
+        <newConstruction>1</newConstruction>
+        <listingAgent>
+            <name>Mr. John Doe</name>
+            <telephone type="BH">05 1234 5678</telephone>
+            <telephone type="mobile">0418 123 456</telephone>
+            <email>jdoe@somedomain.com.au</email>
+            <twitterURL>https://www.twitter.com/JohnDoe</twitterURL>
+        </listingAgent>
+        <price display="yes">500000</price>
+        <priceView>Between $400,000 and $600,000</priceView>
+        <address display="yes">
+            <subNumber>2</subNumber>
+            <streetNumber>39</streetNumber>
+            <street>Main Road</street>
+            <suburb display="yes">RICHMOND</suburb>
+            <state>Vic</state>
+            <postcode>3121</postcode>
+            <country>AUS</country>
+        </address>
+        <municipality>Yarra</municipality>
+        <streetDirectory type="melways">
+            <page>44</page>
+            <reference>G7</reference>
+        </streetDirectory>
+        <category name="House" />
+        <headline>SHOW STOPPER!!!</headline>
+        <description>Don't pass up an opportunity like this! First to inspect will buy! Close to local amenities and schools. Features lavishly appointed bathrooms, modern kitchen, rustic outhouse.Don't pass up an opportunity like this! First to inspect will buy! Close to local amenities and schools. Features lavishly appointed bathrooms, modern kitchen, rustic outhouse.</description>
+        <features>
+            <bedrooms>4</bedrooms>
+            <bathrooms>2</bathrooms>
+            <ensuite>2</ensuite>
+            <garages>3</garages>
+            <carports>2</carports>
+            <remoteGarage>yes</remoteGarage>
+            <secureParking>yes</secureParking>
+            <airConditioning>1</airConditioning>
+            <alarmSystem>1</alarmSystem>
+            <vacuumSystem>no</vacuumSystem>
+            <intercom>no</intercom>
+            <pool type="inground">yes</pool>
+            <spa type="inground">no</spa>
+            <tennisCourt>yes</tennisCourt>
+            <balcony>yes</balcony>
+            <deck>yes</deck>
+            <courtyard>yes</courtyard>
+            <outdoorEnt>yes</outdoorEnt>
+            <shed>yes</shed>
+            <fullyFenced>yes</fullyFenced>
+            <openFirePlace>1</openFirePlace>
+            <heating type="other" />
+            <hotWaterService type="gas" />
+            <otherFeatures>balcony, courtyard, shed</otherFeatures>
+        </features>
+        <landDetails>
+            <area unit="squareMeter">80</area>
+            <frontage unit="meter">20</frontage>
+            <depth unit="meter" side="rear">40</depth>
+            <depth unit="meter" side="left">60</depth>
+            <depth unit="meter" side="right">20</depth>
+            <crossOver value="left" />
+        </landDetails>
+        <buildingDetails>
+            <area unit="squareMeter">40</area>
+            <newlyBuilt value="yes" />
+            <energyRating>4.5</energyRating>
+        </buildingDetails>
+        <inspectionTimes>
+            <inspection>21-Jan-2009 11:00am to 1:00pm</inspection>
+            <inspection>22-Jan-2009 3:00pm to 3:30pm</inspection>
+        </inspectionTimes>
+        <vendorDetails>
+            <name>Mr. John Doe</name>
+            <telephone type="BH">05 1234 5678</telephone>
+        </vendorDetails>
+        <externalLink href="http%3A%2F%2Fwww%2Eau%2Eopen2view%2Ecom%2Fproperties%2F314244%2Ftour%23floorplan" />
+        <externalLink href="http://www.google.com/hello" />
+        <images>
+            <img id="m" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/imageM.jpg" format="jpg" />
+            <img id="a" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/imageA.jpg" format="jpg" />
+        </images>
+        <objects>
+            <floorplan id="1" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/floorplan1.gif"
+                       format="gif" />
+            <floorplan id="2" modTime="2009-01-01-12:30:00" url="http://www.someWebSite.com.au/tmp/floorplan2.gif"
+                       format="gif" />
+        </objects>
+        <media>
+          <attachment usage="statementOfInformation" id="aaaa1111" url="http://www.someWebSite.com.au/tmp/soi-doc-1.gif"></attachment>
+        </media>
+        <videoLink href="http://www.foo.tv/abcd.html"/>
+        <ecoFriendly>
+            <solarPanels>1</solarPanels>
+            <solarHotWater>0</solarHotWater>
+            <waterTank>1</waterTank>
+            <greyWaterSystem>0</greyWaterSystem>
+        </ecoFriendly>
+    </residential>
+</propertyList>


### PR DESCRIPTION
If no `content-type` was provided in any attachments, then it would crash. It used to be required, now it's optional and I was incorrectly assuming it was always there.

Secondly, attachments can now also include 'agentPhoto' ... not just 'statementOfInformation'. I need to check for that -but- ignore them (versus: error with a warning).